### PR TITLE
Trail percent support

### DIFF
--- a/alpaca-lambda/src/alpaca_crypto_service.ts
+++ b/alpaca-lambda/src/alpaca_crypto_service.ts
@@ -16,8 +16,4 @@ export class AlpacaCryptoService extends AlpacaService {
                 .catch(() => resolve(0)); // return 0 for now, there are symbols for which 'no trade found' is thrown
         });
     }
-
-    protected computeOrderQty(orderMoney: number, askPrice: number): number {
-        return orderMoney / askPrice;
-    }
 }

--- a/alpaca-lambda/src/alpaca_order_service.ts
+++ b/alpaca-lambda/src/alpaca_order_service.ts
@@ -1,0 +1,91 @@
+import { AlpacaClient, Order, PlaceOrder } from '@master-chief/alpaca';
+import { TradeSignal } from './interfaces/trade_signal';
+import { TradeParams } from './interfaces/trade_config';
+
+export abstract class AlpacaOrderService {
+    protected async getLongBuyMarketOrder(
+        client: AlpacaClient,
+        tradeSignal: TradeSignal,
+        longTradeParams: TradeParams,
+    ): Promise<PlaceOrder> {
+        const orderQty = await this.getOrderQty(client, longTradeParams, tradeSignal);
+
+        return {
+            symbol: tradeSignal.ticker,
+            side: 'buy',
+            type: 'market',
+            time_in_force: 'gtc',
+            extended_hours: longTradeParams.extendedHours ?? false,
+            qty: orderQty,
+        };
+    }
+
+    protected async getLongBuyLimitOrder(
+        client: AlpacaClient,
+        tradeSignal: TradeSignal,
+        longTradeParams: TradeParams,
+    ): Promise<PlaceOrder> {
+        const orderQty = await this.getOrderQty(client, longTradeParams, tradeSignal);
+
+        const placeOrder: PlaceOrder = {
+            symbol: tradeSignal.ticker,
+            side: 'buy',
+            type: 'limit',
+            qty: orderQty,
+            limit_price: Number(tradeSignal.price),
+            time_in_force: 'gtc',
+            extended_hours: longTradeParams.extendedHours ?? false,
+        };
+
+        if (longTradeParams.limitBracket.enabled) {
+            const askPrice = this.getAskPrice(tradeSignal);
+            const stopPrice = askPrice * (1 - longTradeParams.limitBracket.stopPrice / 100);
+            const limitPrice = askPrice * (1 + longTradeParams.limitBracket.takeProfit / 100);
+
+            placeOrder.order_class = 'bracket';
+            placeOrder.stop_loss = { stop_price: this.round(stopPrice) };
+            placeOrder.take_profit = { limit_price: this.round(limitPrice) };
+        }
+
+        return placeOrder;
+    }
+
+    protected async getLongSellTrailingStopOrder(
+        client: AlpacaClient,
+        buyOrder: Order,
+        longTradeParams: TradeParams,
+    ): Promise<PlaceOrder> {
+        return {
+            symbol: buyOrder.symbol,
+            side: 'sell',
+            type: 'trailing_stop',
+            time_in_force: 'gtc',
+            trail_percent: longTradeParams?.trailingStop?.trailPercent ?? 2,
+            extended_hours: longTradeParams.extendedHours ?? false,
+            qty: buyOrder.qty,
+        };
+    }
+
+    private async getOrderQty(
+        client: AlpacaClient,
+        longTradeParams: TradeParams,
+        tradeSignal: TradeSignal,
+    ): Promise<number> {
+        const buyingPower: number = (await client.getAccount()).buying_power;
+
+        //substract order size percentage from buyingPower
+        const orderMoney: number = buyingPower - buyingPower * (1 - longTradeParams.orderSize / 100);
+        return Math.round(orderMoney / this.getAskPrice(tradeSignal));
+    }
+
+    /**
+     * Gets ask price from the signal instead of Alpaca due to potential MKT data delays.
+     */
+    private getAskPrice(tradeSignal: TradeSignal): number {
+        return Number(tradeSignal.price);
+    }
+
+    private round(num: number): number {
+        return Math.round((num + Number.EPSILON) * 100) / 100;
+    }
+}

--- a/alpaca-lambda/src/alpaca_order_service.ts
+++ b/alpaca-lambda/src/alpaca_order_service.ts
@@ -37,7 +37,7 @@ export abstract class AlpacaOrderService {
             extended_hours: longTradeParams.extendedHours ?? false,
         };
 
-        if (longTradeParams.limitBracket.enabled) {
+        if (longTradeParams.limitBracket?.enabled) {
             const askPrice = this.getAskPrice(tradeSignal);
             const stopPrice = askPrice * (1 - longTradeParams.limitBracket.stopPrice / 100);
             const limitPrice = askPrice * (1 + longTradeParams.limitBracket.takeProfit / 100);
@@ -45,6 +45,13 @@ export abstract class AlpacaOrderService {
             placeOrder.order_class = 'bracket';
             placeOrder.stop_loss = { stop_price: this.round(stopPrice) };
             placeOrder.take_profit = { limit_price: this.round(limitPrice) };
+        }
+
+        if (longTradeParams.limit?.enabled) {
+            const askPrice = this.getAskPrice(tradeSignal);
+            const stopPrice = askPrice * (1 - longTradeParams.limit.stopPrice / 100);
+
+            placeOrder.stop_loss = { stop_price: this.round(stopPrice) };
         }
 
         return placeOrder;
@@ -60,7 +67,7 @@ export abstract class AlpacaOrderService {
             side: 'sell',
             type: 'trailing_stop',
             time_in_force: 'gtc',
-            trail_percent: longTradeParams?.trailingStop?.trailPercent ?? 2,
+            trail_percent: longTradeParams.trailingStop?.trailPercent ?? 2,
             extended_hours: longTradeParams.extendedHours ?? false,
             qty: buyOrder.qty,
         };

--- a/alpaca-lambda/src/alpaca_service.ts
+++ b/alpaca-lambda/src/alpaca_service.ts
@@ -62,7 +62,7 @@ export abstract class AlpacaService extends AlpacaOrderService {
         try {
             await this.cancelOpenOrders(client, tradeSignal.ticker);
             const closeOrder: Order = await client.closePosition({ symbol: tradeSignal.ticker });
-            console.info('Position closed: ', closeOrder);
+            console.info('Position closed: ', JSON.stringify(closeOrder));
 
             return this.buildSuccessResponse(JSON.stringify(closeOrder));
         } catch (err) {
@@ -88,7 +88,7 @@ export abstract class AlpacaService extends AlpacaOrderService {
                 throw new Error(`Unsupported order type received: ${JSON.stringify(tradeSignal)}`);
             }
 
-            console.info('Submitting Long Buy order: ', placeOrder);
+            console.info('Submitting Long Buy order: ', JSON.stringify(placeOrder));
             buyOrder = await client.placeOrder(placeOrder);
             buyOrder = await this.awaitOrderFillOrCancel(
                 client,
@@ -104,24 +104,17 @@ export abstract class AlpacaService extends AlpacaOrderService {
                         buyOrder,
                         this.longTradeParams,
                     );
-                    console.info(`Submitted Long Sell TRAILING order.`, placeTrailingOrder);
+                    console.info(`Submitted Long Sell TRAILING order.`, JSON.stringify(placeTrailingOrder));
                     trailingSellOrder = await client.placeOrder(placeTrailingOrder);
-                    console.info(`Placed Long Sell TRAILING order.`, trailingSellOrder);
+                    console.info(`Placed Long Sell TRAILING order.`, JSON.stringify(trailingSellOrder));
                 }
             }
-            console.info(
-                'EXECUTION COMPLETED :',
-                '\nSIGNAL ',
-                tradeSignal,
-                '\nBUY ORDER ==>',
-                placeOrder,
-                '\nBUY ORDER <==',
-                buyOrder,
-                '\nSTOP ORDER ==> ',
-                placeTrailingOrder,
-                '\nSTOP ORDER <==',
-                trailingSellOrder,
-            );
+            console.info(`EXECUTION COMPLETED 
+                \nSIGNAL ${JSON.stringify(tradeSignal)} 
+                \nBUY ORDER ==> ${JSON.stringify(placeOrder)} 
+                \nBUY ORDER <== ${JSON.stringify(buyOrder)} 
+                \nSTOP ORDER ==> ${JSON.stringify(placeTrailingOrder)} 
+                \nSTOP ORDER <== ${JSON.stringify(trailingSellOrder)}`);
         } catch (err) {
             return this.errorResponse(err, tradeSignal);
         }
@@ -142,7 +135,7 @@ export abstract class AlpacaService extends AlpacaOrderService {
         while (elapsedMillis < maxWaitMillis) {
             const order = await getOrder();
             if (order.status == 'filled') {
-                console.info(`Order filled:`, order, 'Elapsed Milliseconds', elapsedMillis);
+                console.info(`Order filled:`, JSON.stringify(order), 'Elapsed Milliseconds', elapsedMillis);
                 return order;
             }
 
@@ -161,7 +154,7 @@ export abstract class AlpacaService extends AlpacaOrderService {
         const openOrders = await client.getOrders({ status: 'open', symbols: [symbol] });
 
         for (const order of openOrders) {
-            console.warn('Cancel order: ', order);
+            console.warn('Cancel order: ', JSON.stringify(order));
             try {
                 await client.cancelOrder({ order_id: order.id });
             } catch (err) {

--- a/alpaca-lambda/src/alpaca_service.ts
+++ b/alpaca-lambda/src/alpaca_service.ts
@@ -125,15 +125,15 @@ export abstract class AlpacaService extends AlpacaOrderService {
             }
             console.info(
                 'EXECUTION COMPLETED :',
-                'SIGNAL ',
+                '\nSIGNAL ',
                 tradeSignal,
-                'BUY ORDER ==>',
+                '\nBUY ORDER ==>',
                 placeOrder,
-                'BUY ORDER <==',
+                '\nBUY ORDER <==',
                 buyOrder,
-                'STOP ORDER ==> ',
+                '\nSTOP ORDER ==> ',
                 placeTrailingOrder,
-                'STOP ORDER <==',
+                '\nSTOP ORDER <==',
                 trailingSellOrder,
             );
         } catch (err) {

--- a/alpaca-lambda/src/alpaca_service.ts
+++ b/alpaca-lambda/src/alpaca_service.ts
@@ -6,14 +6,16 @@ import { AlpacaError } from './interfaces/alpaca_error';
 import { OrderType } from '@master-chief/alpaca/@types/entities';
 import { TradeConfig, TradeParams } from './interfaces/trade_config';
 import { AlpacaClientExtention } from './alpaca_client_extention';
+import { AlpacaOrderService } from './alpaca_order_service';
 
-export abstract class AlpacaService {
+export abstract class AlpacaService extends AlpacaOrderService {
     private paperClient: AlpacaClientExtention;
     private liveClient: AlpacaClientExtention;
     private longTradeParams: TradeParams;
     private shortTradeParams: TradeParams;
 
     constructor(tradeConfig: TradeConfig) {
+        super();
         this.paperClient = new AlpacaClientExtention({
             credentials: credentials.paper,
             rate_limit: true,
@@ -52,9 +54,7 @@ export abstract class AlpacaService {
         return this.buildSuccessResponse(JSON.stringify({ message: 'Unknown route' }));
     }
 
-    protected abstract getCurrentPrice(client: AlpacaClient, tradeSignal: TradeSignal): Promise<number>;
-
-    protected abstract computeOrderQty(orderMoney: number, askPrice: number): number;
+    // protected abstract getCurrentPrice(client: AlpacaClient, tradeSignal: TradeSignal): Promise<number>;
 
     private async processSellSignal(client: AlpacaClient, tradeSignal: TradeSignal): Promise<APIGatewayProxyResult> {
         let closeOrder: Order;
@@ -85,50 +85,116 @@ export abstract class AlpacaService {
     }
 
     private async processBuySignal(client: AlpacaClient, tradeSignal: TradeSignal): Promise<APIGatewayProxyResult> {
+        let placeOrder: PlaceOrder;
         let buyOrder: Order;
+        let trailingSellOrder: Order | undefined = undefined;
+        let placeTrailingOrder: PlaceOrder | undefined = undefined;
 
         try {
-            //get account buying power
-            const buyingPower: number = (await client.getAccount()).buying_power;
+            const orderType = this.longTradeParams.orderType as OrderType;
+            const isOrderCanceled = (order: Order) => order.status == 'canceled' || order.status == 'pending_cancel';
 
-            //substract order size percentage from buyingPower
-            const orderMoney: number = buyingPower - buyingPower * (1 - this.longTradeParams.orderSize / 100);
-
-            //get latest price for the symbol
-            const askPrice: number = await this.getCurrentPrice(client, tradeSignal);
-
-            let placeOrder: PlaceOrder;
-
-            if (this.longTradeParams.notional) {
-                //use orderMoney as notional
-                console.info(`buyingPower: ${buyingPower}, orderMoney: ${orderMoney}, askPrice: ${askPrice}`);
-
-                placeOrder = this.buildBuyPlaceOrder(tradeSignal, orderMoney);
+            if (orderType == 'market') {
+                placeOrder = await super.getLongBuyMarketOrder(client, tradeSignal, this.longTradeParams);
+            } else if (orderType == 'limit') {
+                placeOrder = await super.getLongBuyLimitOrder(client, tradeSignal, this.longTradeParams);
             } else {
-                //calculate order quantity
-                const orderQty = this.computeOrderQty(orderMoney, askPrice);
-
-                console.info(
-                    `buyingPower: ${buyingPower}, orderMoney: ${orderMoney}, askPrice: ${askPrice}, orderQty: ${orderQty}`,
-                );
-
-                placeOrder = this.buildBuyPlaceOrder(tradeSignal, orderQty);
+                throw new Error(`Unsupported order type received: ${JSON.stringify(tradeSignal)}`);
             }
 
-            //att stop loss if tradeConfig.stopLoss = true
-            placeOrder = this.attachStopLoss(placeOrder, askPrice);
-
-            console.info('Submit order: ', placeOrder);
-
+            console.info('Submitting Long Buy order: ', placeOrder);
             buyOrder = await client.placeOrder(placeOrder);
+            buyOrder = await this.awaitOrderFillOrCancel(
+                client,
+                buyOrder.id,
+                this.longTradeParams.cancelPendingOrderPeriod,
+            );
+
+            if (!isOrderCanceled(buyOrder)) {
+                //trailing stop works on limit orders only if there are no limit brackets.
+                if (this.longTradeParams?.trailingStop?.enabled && !this.longTradeParams.limitBracket.enabled) {
+                    placeTrailingOrder = await super.getLongSellTrailingStopOrder(
+                        client,
+                        buyOrder,
+                        this.longTradeParams,
+                    );
+                    console.info(`Submitted Long Sell TRAILING order.`, placeTrailingOrder);
+                    trailingSellOrder = await client.placeOrder(placeTrailingOrder);
+                    console.info(`Placed Long Sell TRAILING order.`, trailingSellOrder);
+                }
+            }
+            console.info(
+                'EXECUTION COMPLETED :',
+                'SIGNAL ',
+                tradeSignal,
+                'BUY ORDER ==>',
+                placeOrder,
+                'BUY ORDER <==',
+                buyOrder,
+                'STOP ORDER ==> ',
+                placeTrailingOrder,
+                'STOP ORDER <==',
+                trailingSellOrder,
+            );
         } catch (err) {
             return this.errorResonse(err, tradeSignal);
         }
 
-        console.info('Buy order placed: ', buyOrder);
-
-        return this.buildSuccessResponse(JSON.stringify(buyOrder));
+        return this.buildSuccessResponse(JSON.stringify([buyOrder]));
     }
+
+    private async awaitOrderFillOrCancel(
+        client: AlpacaClient,
+        orderId: string,
+        maxWaitSeconds: number,
+    ): Promise<Order> {
+        const maxWaitMillis = this.longTradeParams.cancelPendingOrderPeriod * 1000;
+        const intervalMillis = 1000; // check status every 1 second
+        let elapsedMillis = 0;
+        const getOrder = async () => client.getOrder({ order_id: orderId });
+
+        while (elapsedMillis < maxWaitMillis) {
+            const order = await getOrder();
+            if (order.status == 'filled') {
+                console.info(`Order filled:`, order);
+                return order;
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, intervalMillis));
+            elapsedMillis += intervalMillis;
+            console.debug(`Waiting for the '${order.status}' order to be filled`);
+        }
+
+        // max wait time reached without the order being filled
+        console.info(`Order ${orderId} was not filled within ${maxWaitSeconds} seconds. Canceling...`);
+        await client.cancelOrder({ order_id: orderId });
+        return await getOrder();
+    }
+
+    private async cancelOpenOrders(client: AlpacaClient, symbol: string) {
+        const openOrders = await client.getOrders({ status: 'open', symbols: [symbol] });
+
+        openOrders.forEach(async (order) => {
+            console.warn('Cancel order: ', order);
+            try {
+                await client.cancelOrder({ order_id: order.id });
+            } catch (err) {
+                console.error(`Failed to cancel order ${order.id}: `, err);
+            }
+        });
+    }
+
+    // private async submitOrder(client: AlpacaClient, placeOrder: PlaceOrder) {
+    //     console.info('Submitted order', placeOrder);
+    //     let order = await client.placeOrder(placeOrder)
+    //
+    //     setTimeout(() => {
+    //         wh (order.status != 'filled') {
+    //             let order = await client.getOrder({order_id: order.id})
+    //         }
+    //     }, this.longTradeParams.cancelPendingOrderPeriod * 1000)
+    //
+    // }
 
     private async buildSuccessResponse(data: string): Promise<APIGatewayProxyResult> {
         return this.buildResponse(200, data);
@@ -157,61 +223,5 @@ export abstract class AlpacaService {
             return this.buildResponse(403, JSON.stringify(err));
 
         return this.buildResponse(500, JSON.stringify(err));
-    }
-
-    private buildBuyPlaceOrder(tradeSignal: TradeSignal, qty: number): PlaceOrder {
-        let order: PlaceOrder = {
-            symbol: tradeSignal.ticker,
-            side: 'buy',
-            type: this.longTradeParams.orderType as OrderType,
-            time_in_force: this.longTradeParams.timeInForce,
-            extended_hours: this.longTradeParams.extendedHours ?? false,
-        };
-
-        this.calculateNational(order, qty)
-        this.calculateQty(order, qty)
-        this.calculateLimitPrice(order, tradeSignal)
-        this.calculateTrailPercent(order)
-
-        return order;
-    }
-
-    private calculateNational(order: PlaceOrder, qty: number): void {
-        if (this.longTradeParams.notional) {
-            order.notional = qty;
-        }
-    }
-
-    private calculateQty(order: PlaceOrder, qty: number): void {
-        if (!this.longTradeParams.notional) {
-            order.qty = qty
-        }
-    }
-
-    private calculateLimitPrice(order: PlaceOrder, tradeSignal: TradeSignal): void {
-        if (this.longTradeParams.orderType == 'limit') {
-            order.limit_price = Number(tradeSignal.price)
-        }
-    }
-
-    private calculateTrailPercent(order: PlaceOrder): void {
-        if (this.longTradeParams.orderType == 'trailing_stop') {
-            order.trail_percent = this.longTradeParams.trailPercent;
-        }
-    }
-
-    private attachStopLoss(placeOrder: PlaceOrder, askPrice: number): PlaceOrder {
-        if (this.longTradeParams.stopLoss && this.longTradeParams.stopPrice && this.longTradeParams.takeProfit) {
-            const stopPrice = askPrice * (1 - this.longTradeParams.stopPrice / 100);
-            const limitPrice = askPrice * (1 + this.longTradeParams.takeProfit / 100);
-            placeOrder.stop_loss = { stop_price: this.round(stopPrice) };
-            placeOrder.take_profit = { limit_price: this.round(limitPrice) };
-            placeOrder.order_class = 'bracket';
-        }
-        return placeOrder;
-    }
-
-    private round(num: number): number {
-        return Math.round((num + Number.EPSILON) * 100) / 100;
     }
 }

--- a/alpaca-lambda/src/alpaca_stock_service.ts
+++ b/alpaca-lambda/src/alpaca_stock_service.ts
@@ -16,8 +16,4 @@ export class AlpacaStockService extends AlpacaService {
                 .catch((err) => reject(err));
         });
     }
-
-    protected computeOrderQty(orderMoney: number, askPrice: number): number {
-        return Math.round(orderMoney / askPrice);
-    }
 }

--- a/alpaca-lambda/src/app.ts
+++ b/alpaca-lambda/src/app.ts
@@ -3,6 +3,7 @@ import { config, cryptoConfig } from './config';
 import { AlpacaStockService } from './alpaca_stock_service';
 import { TradeConfig } from './interfaces/trade_config';
 import { AlpacaCryptoService } from './alpaca_crypto_service';
+
 /**
  *
  * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
@@ -18,7 +19,6 @@ export const lambdaPaperHandler = async (event: APIGatewayProxyEvent): Promise<A
 
     return aplacaService.processPaperEvent(event);
 };
-
 export const lambdaLiveHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     const aplacaService = new AlpacaStockService(config as TradeConfig);
 

--- a/alpaca-lambda/src/config.ts
+++ b/alpaca-lambda/src/config.ts
@@ -8,7 +8,7 @@ export const config = {
         cancelPendingOrderPeriod: 5, // in seconds, fail as fast as possible. Do not change unless you have a good reason
         trailingStop: {
             enabled: true, // true, false
-            trailPercent: 2, // % value away from the highest watermark
+            trailPercent: 5, // % value away from the highest watermark
         },
         limitBracket: {
             enabled: false, // true, false - always set it to false if trailingStop.enabled=true
@@ -24,10 +24,9 @@ export const cryptoConfig = {
         orderSize: 3,
         orderType: 'limit',
         cancelPendingOrderPeriod: 5, // in seconds, fail as fast as possible. Do not change unless you have a good reason
-        limitBracket: {
+        limit: {
             enabled: true,
             stopPrice: 3,
-            takeProfit: 6,
         },
     } as TradeParams,
 };

--- a/alpaca-lambda/src/config.ts
+++ b/alpaca-lambda/src/config.ts
@@ -1,26 +1,38 @@
+import { TradeParams } from './interfaces/trade_config';
+
 export const config = {
     long: {
-        orderSize: 3,               // % from byuing power
-        orderType: 'trailing_stop', // limit, market, trailing_stop
-        timeInForce: 'day',         // day, gtc, ...
-        trailPercent: 5,            // % value away from the highest watermark
-        stopPrice: 3,               // % below order price
-        takeProfit: 6,              // % above order price
-        stopLoss: false,            // true, false
-        notional: false,            // ture, false - if false system will calculate order qty
-        extendedHours: false,       // true | false
-    },
-    short: {},
+        orderSize: 3, // % from byuing power
+        orderType: 'limit', // limit, market
+        extendedHours: false, // true | false
+        cancelPendingOrderPeriod: 120, // 120 seconds
+        trailingStop: {
+            enabled: true, // true, false
+            trailPercent: 2, // % value away from the highest watermark
+        },
+        limitBracket: {
+            enabled: false, // true, false - always set it to false if trailingStop.enabled=true
+            stopPrice: 3, // % below order price
+            takeProfit: 999, // % above order price
+        },
+    } as TradeParams,
+    short: {} as TradeParams,
 };
 
 export const cryptoConfig = {
     long: {
         orderSize: 3,
-        orderType: 'market',
-        notional: true,
-    },
+        orderType: 'limit',
+        cancelPendingOrderPeriod: 120, // 120 seconds
+        limitBracket: {
+            enabled: true,
+            stopPrice: 3,
+            takeProfit: 6,
+        },
+    } as TradeParams,
 };
 
+//TODO: Check with Vlad if those can be added in to AWS Secrets
 export const credentials = {
     paper: {
         key: 'YOUR_KEY',

--- a/alpaca-lambda/src/config.ts
+++ b/alpaca-lambda/src/config.ts
@@ -5,7 +5,7 @@ export const config = {
         orderSize: 3, // % from byuing power
         orderType: 'limit', // limit, market
         extendedHours: false, // true | false
-        cancelPendingOrderPeriod: 120, // 120 seconds
+        cancelPendingOrderPeriod: 5, // in seconds, fail as fast as possible. Do not change unless you have a good reason
         trailingStop: {
             enabled: true, // true, false
             trailPercent: 2, // % value away from the highest watermark
@@ -23,7 +23,7 @@ export const cryptoConfig = {
     long: {
         orderSize: 3,
         orderType: 'limit',
-        cancelPendingOrderPeriod: 120, // 120 seconds
+        cancelPendingOrderPeriod: 5, // in seconds, fail as fast as possible. Do not change unless you have a good reason
         limitBracket: {
             enabled: true,
             stopPrice: 3,
@@ -32,7 +32,9 @@ export const cryptoConfig = {
     } as TradeParams,
 };
 
-//TODO: Check with Vlad if those can be added in to AWS Secrets
+//TODO: Check with Vlad if those should in to AWS Secrets. It costs :(
+//      $0.40 per secret per month
+//      $0.05 per 10,000 API calls
 export const credentials = {
     paper: {
         key: 'YOUR_KEY',

--- a/alpaca-lambda/src/interfaces/trade_config.ts
+++ b/alpaca-lambda/src/interfaces/trade_config.ts
@@ -5,7 +5,12 @@ export interface TradeParams {
     notional: boolean;
     extendedHours?: boolean;
     cancelPendingOrderPeriod: number;
-    limitBracket: {
+    limit?: {
+        enabled: boolean;
+        stopPrice: number;
+        takeProfit: number;
+    };
+    limitBracket?: {
         enabled: boolean;
         stopPrice: number;
         takeProfit: number;

--- a/alpaca-lambda/src/interfaces/trade_config.ts
+++ b/alpaca-lambda/src/interfaces/trade_config.ts
@@ -2,12 +2,18 @@ export interface TradeParams {
     orderSize: number;
     orderType: string;
     timeInForce: 'day' | 'gtc';
-    stopLoss?: boolean;
-    stopPrice?: number;
-    takeProfit?: number;
-    trailPercent?: number;
     notional: boolean;
     extendedHours?: boolean;
+    cancelPendingOrderPeriod: number;
+    limitBracket: {
+        enabled: boolean;
+        stopPrice: number;
+        takeProfit: number;
+    };
+    trailingStop?: {
+        enabled: boolean;
+        trailPercent: number;
+    };
 }
 
 export interface TradeConfig {


### PR DESCRIPTION
⚠️  TO BE DISCUSSED BEFORE MERGED

- Moved orders construction logic into a separate class 
- Slightly refactored config
- Removed notional related logic - most probably we will always want to operate with portfolio  percent
- Updated order placement logic. On order submission, by default, it will wait for 5 seconds with an interval of 0.5 seconds to check if the order is filled. If not filled in the expected threshold it is canceled.

### Testing completed
- ✔️  Tested trailing stop with a limit order
- ✔️ Tested trailing stop with a market order
- ✔️ Tested crypto orders with limit and market orders

### Trailing stop observations
Tested manually in Alpaca by setting trailing loss of **2%**.
At the end of the day observed a large gap in results compared with Victor's setup. Trailing loss of 2% secured 0.34% for me where Victor gained 2.4%

#### Conclusion 
A trailing stop of 2-3% is too tight since we will hit it often due to the nature of the Trailing Stop calculation HWT+2%. 
![image](https://user-images.githubusercontent.com/10146844/224467310-2f4a5c8d-bede-4a90-b93a-3cb1c8e36a6b.png)
  