### PR TITLE
chore: enhanced logging to have better AWS log insight.

### DIFF
--- a/alpaca-lambda/src/alpaca_service.ts
+++ b/alpaca-lambda/src/alpaca_service.ts
@@ -109,12 +109,12 @@ export abstract class AlpacaService extends AlpacaOrderService {
                     console.info(`Placed Long Sell TRAILING order.`, JSON.stringify(trailingSellOrder));
                 }
             }
-            console.info(`EXECUTION COMPLETED 
-                \nSIGNAL ${JSON.stringify(tradeSignal)} 
-                \nBUY ORDER ==> ${JSON.stringify(placeOrder)} 
-                \nBUY ORDER <== ${JSON.stringify(buyOrder)} 
-                \nSTOP ORDER ==> ${JSON.stringify(placeTrailingOrder)} 
-                \nSTOP ORDER <== ${JSON.stringify(trailingSellOrder)}`);
+            //Reach log statements - used in AWS log insights queries to build reports
+            console.info(`SIGNAL PROCESSED ${JSON.stringify(tradeSignal)}`);
+            console.info(`BUY ORDER PAYLOAD ${JSON.stringify(placeOrder)}`);
+            console.info(`BUY ORDER RESPONSE ${JSON.stringify(buyOrder)}`);
+            console.info(`STOP ORDER PAYLOAD ${JSON.stringify(placeTrailingOrder)}`);
+            console.info(`STOP ORDER RESPONSE ${JSON.stringify(trailingSellOrder)}`);
         } catch (err) {
             return this.errorResponse(err, tradeSignal);
         }


### PR DESCRIPTION
AWS Log insights work better with one JSON per log entry, which makes queries more flexible when it comes to specific business requirements. 

ℹ️ I will share some simple queries in a documentation-type issue

![image](https://user-images.githubusercontent.com/10146844/224510091-b6d2add4-76c7-4a92-9973-036a5f6bfc23.png)
