### PR TITLE
bug: do not sent a trailing order for sale signals

### DIFF
--- a/alpaca-lambda/src/alpaca_order_service.ts
+++ b/alpaca-lambda/src/alpaca_order_service.ts
@@ -85,6 +85,19 @@ export abstract class AlpacaOrderService {
         return Math.round(orderMoney / this.getAskPrice(tradeSignal));
     }
 
+    protected isOrderCanceled(order: Order): boolean {
+        return order.status == 'canceled' || order.status == 'pending_cancel';
+    }
+
+    /**
+     * Check if trailing order is allowed.
+     * Note that Trailing Stop works with limit orders only if there are no limit brackets.
+     */
+    protected isTrailingOrderAllowed(buyOrder: Order, tradeSignal: TradeSignal, tradeParams: TradeParams): boolean {
+        const trailingEnabled = tradeParams.trailingStop?.enabled ?? false;
+        return !this.isOrderCanceled(buyOrder) && tradeSignal.action === 'buy' && trailingEnabled;
+    }
+
     /**
      * Gets ask price from the signal instead of Alpaca due to potential MKT data delays.
      */


### PR DESCRIPTION
Observed that with the sell signal, we are triggering trailing sell as well which is redundant. We want trailing orders only on buy signals.


![image](https://user-images.githubusercontent.com/10146844/225176053-a8580ca8-4e41-4909-93b0-8d6a0cc575c5.png)
