### PR TITLE
feat: added limit order buffer price percent

### DIFF
--- a/alpaca-lambda/src/alpaca_order_service.ts
+++ b/alpaca-lambda/src/alpaca_order_service.ts
@@ -32,7 +32,7 @@ export abstract class AlpacaOrderService {
             side: 'buy',
             type: 'limit',
             qty: orderQty,
-            limit_price: this.round(Number(tradeSignal.price)),
+            limit_price: this.getLimitBuyBufferPerice(tradeSignal, longTradeParams),
             time_in_force: 'gtc',
             extended_hours: longTradeParams.extendedHours ?? false,
         };
@@ -107,5 +107,12 @@ export abstract class AlpacaOrderService {
 
     private round(num: number): number {
         return Math.round((num + Number.EPSILON) * 100) / 100;
+    }
+
+    private getLimitBuyBufferPerice(signal: TradeSignal, params: TradeParams): number {
+        const signalPrice = Number(signal.price);
+        const buffer = (params.limitBuyBufferPercent / 100) * signalPrice;
+
+        return this.round(signalPrice + buffer);
     }
 }

--- a/alpaca-lambda/src/alpaca_service.ts
+++ b/alpaca-lambda/src/alpaca_service.ts
@@ -104,7 +104,7 @@ export abstract class AlpacaService extends AlpacaOrderService {
             }
 
             //Reach log statements - used in AWS log insights queries to build reports
-            console.info(`SIGNAL PROCESSED ${JSON.stringify(tradeSignal)}`);
+            console.info(`SIGNAL PROCESSED ${JSON.stringify(tradeSignal)}, ${JSON.stringify(this.longTradeParams)}`);
             console.info(`BUY ORDER PAYLOAD ${JSON.stringify(placeOrder)}`);
             console.info(`BUY ORDER RESPONSE ${JSON.stringify(buyOrder)}`);
             if (placeTrailingOrder) console.info(`STOP ORDER PAYLOAD ${JSON.stringify(placeTrailingOrder)}`);

--- a/alpaca-lambda/src/config.ts
+++ b/alpaca-lambda/src/config.ts
@@ -4,11 +4,12 @@ export const config = {
     long: {
         orderSize: 3, // % from byuing power
         orderType: 'limit', // limit, market
+        limitBuyBufferPercent: 1, //percent added to the limit price
         extendedHours: false, // true | false
         cancelPendingOrderPeriod: 5, // in seconds, fail as fast as possible. Do not change unless you have a good reason
         trailingStop: {
             enabled: true, // true, false
-            trailPercent: 5, // % value away from the highest watermark
+            trailPercent: 3, // % value away from the highest watermark
         },
         limitBracket: {
             enabled: false, // true, false - always set it to false if trailingStop.enabled=true
@@ -23,7 +24,8 @@ export const cryptoConfig = {
     long: {
         orderSize: 3,
         orderType: 'limit',
-        cancelPendingOrderPeriod: 5, // in seconds, fail as fast as possible. Do not change unless you have a good reason
+        limitBuyBufferPercent: 1,
+        cancelPendingOrderPeriod: 5,
         limit: {
             enabled: true,
             stopPrice: 3,

--- a/alpaca-lambda/src/interfaces/trade_config.ts
+++ b/alpaca-lambda/src/interfaces/trade_config.ts
@@ -1,6 +1,7 @@
 export interface TradeParams {
     orderSize: number;
     orderType: string;
+    limitBuyBufferPercent: number;
     timeInForce: 'day' | 'gtc';
     notional: boolean;
     extendedHours?: boolean;


### PR DESCRIPTION
Added ability to specify limit price percent buffer for buy orders.

Ex: Buy Limit order at `100$` with `1%` buffer will result in a limit order with a price of `101$` 